### PR TITLE
Add mongoose-example to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 secrets.*
 node_modules/
+mongoose-example/


### PR DESCRIPTION
mongoose-example is a disorganized sample project which just outlines some basic functionality for the mongoose ODM. Not intended to be included as a course-project for the public view. 